### PR TITLE
Add extraction logging & inplace toggle

### DIFF
--- a/md_batch_gpt/cli.py
+++ b/md_batch_gpt/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Tuple
 import json
+from .log_io import append_log_record
 
 import typer
 
@@ -49,6 +50,16 @@ def run(
         "--dry-run",
         help="List files to be processed without sending prompts",
     ),
+    inplace: bool = typer.Option(
+        False,
+        "--inplace/--no-inplace",
+        help="Toggle rewrite vs extraction",
+    ),
+    log_file: Path = typer.Option(
+        Path("extracted.txt"),
+        "--log-file",
+        help="Path for extraction log",
+    ),
 ) -> None:
     """Run the batch processor on *folder* using *prompts*."""
     prompt_list = list(prompts)
@@ -76,6 +87,8 @@ def run(
         regex_json=regex_json,
         dry_run=dry_run,
         verbose=verbose,
+        inplace=inplace,
+        log_file=log_file,
     )
     if verbose:
         typer.echo("Done")

--- a/md_batch_gpt/log_io.py
+++ b/md_batch_gpt/log_io.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+def append_log_record(log_path: Path, file_path: Path, prompt_path: Path, output: str):
+    try:
+        relative = file_path.relative_to(Path.cwd())
+    except ValueError:
+        relative = file_path.name
+    header = f"=== {relative} | prompt: {prompt_path.name} ===\n"
+    sep = "\n---\n"
+    with log_path.open("a", encoding="utf-8") as f:
+        f.write(header)
+        f.write(output.rstrip("\n") + "\n")
+        f.write(sep)

--- a/md_batch_gpt/orchestrator.py
+++ b/md_batch_gpt/orchestrator.py
@@ -5,6 +5,7 @@ from typing import List
 
 from .file_io import iter_markdown_files, write_atomic
 from .openai_client import send_prompt
+from .log_io import append_log_record
 import typer
 
 
@@ -16,6 +17,8 @@ def process_folder(
     regex_json: Path | None = None,
     dry_run: bool = False,
     verbose: bool = False,
+    inplace: bool = False,
+    log_file: Path = Path("extracted.txt"),
 ) -> None:
     """Process Markdown files in *folder* using prompts from *prompt_paths*.
 
@@ -23,7 +26,8 @@ def process_folder(
     number of prompts, but make no changes.
     """
     prompts = [
-        Path(p).read_text(encoding="utf-8", errors="replace") for p in prompt_paths
+        (Path(p), Path(p).read_text(encoding="utf-8", errors="replace"))
+        for p in prompt_paths
     ]
     files = list(iter_markdown_files(folder))
     if dry_run:
@@ -34,8 +38,12 @@ def process_folder(
 
     for md_file in files:
         text = md_file.read_text(encoding="utf-8", errors="replace")
-        for idx, prompt in enumerate(prompts):
+        for idx, (prompt_path, prompt) in enumerate(prompts):
             if verbose:
                 typer.echo(f"{md_file}: pass {idx + 1}/{len(prompts)}")
             text = send_prompt(prompt, text, model, max_tokens)
-            write_atomic(md_file, text)
+            if inplace:
+                write_atomic(md_file, text)
+            else:
+                append_log_record(Path(log_file), md_file, prompt_path, text)
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,8 @@ def test_run_max_tokens(monkeypatch, tmp_path: Path):
         regex_json: Path | None = None,
         dry_run: bool = False,
         verbose: bool = False,
+        inplace: bool = False,
+        log_file: Path | None = None,
     ) -> None:
         captured["max_tokens"] = max_tokens
 
@@ -120,6 +122,8 @@ def test_run_regex_json(monkeypatch, tmp_path: Path):
         regex_json: Path | None = None,
         dry_run: bool = False,
         verbose: bool = False,
+        inplace: bool = False,
+        log_file: Path | None = None,
     ) -> None:
         captured["regex_json"] = regex_json
 

--- a/tests/test_log_io.py
+++ b/tests/test_log_io.py
@@ -1,0 +1,12 @@
+import tempfile, textwrap
+from pathlib import Path
+from md_batch_gpt.log_io import append_log_record
+
+def test_append_log_record(tmp_path):
+    log = tmp_path / "log.txt"
+    src = tmp_path / "a.md"; src.write_text("dummy")
+    prm = tmp_path / "p.txt"; prm.write_text("prompt")
+    append_log_record(log, src, prm, "OUTPUT")
+    content = log.read_text(encoding="utf-8")
+    assert "=== a.md | prompt: p.txt ===" in content
+    assert "OUTPUT" in content

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -37,7 +37,7 @@ def test_process_folder(monkeypatch, tmp_path: Path):
     p2 = tmp_path / "p2.txt"
     p2.write_text("p2")
 
-    orch.process_folder(tmp_path, [p1, p2], model="m")
+    orch.process_folder(tmp_path, [p1, p2], model="m", inplace=True)
 
     assert (tmp_path / "a.md").read_text() == "A[p1][p2]"
     assert (sub / "b.md").read_text() == "B[p1][p2]"
@@ -94,7 +94,7 @@ def test_process_folder_verbose(monkeypatch, tmp_path: Path, capsys):
     p2 = tmp_path / "p2.txt"
     p2.write_text("p2")
 
-    orch.process_folder(tmp_path, [p1, p2], model="m", verbose=True)
+    orch.process_folder(tmp_path, [p1, p2], model="m", verbose=True, inplace=True)
 
     out_lines = capsys.readouterr().out.splitlines()
     assert "a.md: pass 1/2" in out_lines[0]
@@ -122,7 +122,7 @@ def test_process_folder_max_tokens(monkeypatch, tmp_path: Path):
     p = tmp_path / "p.txt"
     p.write_text("p")
 
-    orch.process_folder(tmp_path, [p], model="m", max_tokens=99)
+    orch.process_folder(tmp_path, [p], model="m", max_tokens=99, inplace=True)
 
     assert captured["max_tokens"] == 99
 
@@ -144,7 +144,7 @@ def test_process_folder_invalid_bytes(monkeypatch, tmp_path: Path):
     p = tmp_path / "p.txt"
     p.write_bytes(b"p\xfe")
 
-    orch.process_folder(tmp_path, [p], model="m")
+    orch.process_folder(tmp_path, [p], model="m", inplace=True)
 
     # Replacement character should appear for invalid bytes
     assert md.read_text(encoding="utf-8") == "A\ufffdB[p\ufffd]"


### PR DESCRIPTION
## Summary
- implement append_log_record for extraction mode
- extend CLI with `--log-file` and `--inplace/--no-inplace`
- add inplace & log_file support in orchestrator
- create new tests for logging
- adjust existing tests for new parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6877b06f2b4c8326b4cdc65d66d92adb