### PR TITLE
Add verbose log hook and resolve log file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## [0.1.1] - 2025-07-17
+### Added
+- Verbose mode now prints log record details as they are written
+- Log file path is resolved relative to the current working directory
+- End-to-end CLI tests
+### Fixed
+- Clear error message when the log file cannot be written

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ poetry run mdgpt run \
   --no-inplace                      # default; explicit for clarity
 ```
 
+The `--log-file` path may be relative or absolute; relative paths are resolved
+against your current working directory.
+If the path cannot be written to, the command exits with an error.
+
 ### Log Record Format (human-readable blocks)
 
 Each record starts with a header line, then the model output, then a `---` separator:
@@ -65,10 +69,12 @@ In this mode the tool writes the transformed text back to the same file atomical
 | --model | str | from pyproject.toml or o3 fallback | Passed to OpenAI Chat Completions. |
 | --max-tokens | int | None | Cap completion size. |
 | --regex-json | path | None | Optional regex filters (future / experimental). |
-| --verbose, -v | flag | False | Echo progress (file, pass idx). |
+| --verbose, -v | flag | False | Echo progress (file, pass idx); also prints log record info in Extraction Mode. |
 | --dry-run | flag | False | Print files + prompt count; no API calls; no log writes; no disk changes. |
 | --log-file | path | ./extracted.txt | Where Extraction Mode appends records. (new) |
 | --inplace / --no-inplace | flag | --no-inplace | Toggle Extraction vs Rewrite modes. (new) |
+
+When verbose mode is active, each log record is announced with its index, file path, and prompt name.
 
 ### Dry Run
 

--- a/md_batch_gpt/cli.py
+++ b/md_batch_gpt/cli.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List, Tuple
-import json
-from .log_io import append_log_record
 
 import typer
 
@@ -79,6 +77,7 @@ def run(
         typer.echo(f"Model: {model} Max tokens: {max_tokens}")
         if regex_json:
             typer.echo(f"Regex JSON: {regex_json}")
+    resolved_log_file = Path.cwd() / log_file
     process_folder(
         folder,
         prompt_list,
@@ -88,7 +87,7 @@ def run(
         dry_run=dry_run,
         verbose=verbose,
         inplace=inplace,
-        log_file=log_file,
+        log_file=resolved_log_file,
     )
     if verbose:
         typer.echo("Done")

--- a/md_batch_gpt/log_io.py
+++ b/md_batch_gpt/log_io.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import typer
 
 
 def append_log_record(log_path: Path, file_path: Path, prompt_path: Path, output: str):
@@ -8,7 +9,11 @@ def append_log_record(log_path: Path, file_path: Path, prompt_path: Path, output
         relative = file_path.name
     header = f"=== {relative} | prompt: {prompt_path.name} ===\n"
     sep = "\n---\n"
-    with log_path.open("a", encoding="utf-8") as f:
-        f.write(header)
-        f.write(output.rstrip("\n") + "\n")
-        f.write(sep)
+    try:
+        with log_path.open("a", encoding="utf-8") as f:
+            f.write(header)
+            f.write(output.rstrip("\n") + "\n")
+            f.write(sep)
+    except OSError as exc:
+        typer.echo(f"Cannot write to log file: {exc}", err=True)
+        raise typer.Exit(code=1)

--- a/md_batch_gpt/orchestrator.py
+++ b/md_batch_gpt/orchestrator.py
@@ -46,4 +46,5 @@ def process_folder(
                 write_atomic(md_file, text)
             else:
                 append_log_record(Path(log_file), md_file, prompt_path, text)
-
+                if verbose:
+                    typer.echo(f"log record {idx + 1}: {md_file} {prompt_path.name}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "md-batch-gpt"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = [
     {name = "Codex", email = "codex@openai.com"}

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1,0 +1,17 @@
+import os
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+
+def run_cli(args: Iterable[str], cwd: Path) -> subprocess.CompletedProcess:
+    """Run the mdgpt CLI via poetry and return the completed process."""
+    cmd = ["poetry", "run", "mdgpt", *args]
+    env = os.environ.copy()
+    env.update(
+        {
+            "OPENAI_API_KEY": "dummy",
+            "PYTHONPATH": str(Path(__file__).parent / "stubs"),
+        }
+    )
+    return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, env=env)

--- a/tests/stubs/openai.py
+++ b/tests/stubs/openai.py
@@ -1,0 +1,40 @@
+class RateLimitError(Exception):
+    pass
+
+
+class APIStatusError(Exception):
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+class APIConnectionError(Exception):
+    pass
+
+
+class _Message:
+    def __init__(self, content):
+        self.content = content
+
+
+class _Choice:
+    def __init__(self, content):
+        self.message = _Message(content)
+
+
+class _Completions:
+    def create(self, **params):
+        prompt = params.get("messages")[0]["content"]
+        content = params.get("messages")[1]["content"]
+        return type(
+            "Resp", (), {"choices": [_Choice(f"{content}[{prompt.strip()}]")]}
+        )()
+
+
+class _Chat:
+    def __init__(self):
+        self.completions = _Completions()
+
+
+class OpenAI:
+    def __init__(self, api_key=None):
+        self.chat = _Chat()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,3 +147,146 @@ def test_run_regex_json(monkeypatch, tmp_path: Path):
 
     assert result.exit_code == 0, result.stdout
     assert captured["regex_json"] == regex_path
+
+
+def test_end_to_end_modes(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+
+    cli = import_cli()
+
+    monkeypatch.setattr(
+        "md_batch_gpt.orchestrator.send_prompt",
+        lambda prompt, content, model, max_tokens=None: f"{content}[{prompt.strip()}]",
+    )
+
+    p1 = tmp_path / "p1.txt"
+    p1.write_text("P1")
+    p2 = tmp_path / "p2.txt"
+    p2.write_text("P2")
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    f1 = docs / "a.md"
+    f1.write_text("A")
+    f2 = docs / "b.md"
+    f2.write_text("B")
+
+    log_file = tmp_path / "extracted.txt"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            str(docs),
+            "--prompts",
+            str(p1),
+            "--prompts",
+            str(p2),
+            "--log-file",
+            str(log_file),
+            "--no-inplace",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert f1.read_text() == "A"
+    assert f2.read_text() == "B"
+    log_content = log_file.read_text()
+    assert "=== a.md | prompt: p1.txt ===" in log_content
+    assert "A[P1]" in log_content
+    assert "A[P1][P2]" in log_content
+    assert "=== b.md | prompt: p2.txt ===" in log_content
+    assert "B[P1][P2]" in log_content
+
+    log_file.write_text("")
+    result = runner.invoke(
+        cli.app,
+        [
+            str(docs),
+            "--prompts",
+            str(p1),
+            "--prompts",
+            str(p2),
+            "--log-file",
+            str(log_file),
+            "--inplace",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert f1.read_text() == "A[P1][P2]"
+    assert f2.read_text() == "B[P1][P2]"
+    assert log_file.read_text() == ""
+
+
+def test_unwritable_log_file(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+
+    cli = import_cli()
+    monkeypatch.setattr(
+        "md_batch_gpt.orchestrator.send_prompt",
+        lambda prompt, content, model, max_tokens=None: content,
+    )
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("A")
+
+    log_dir = tmp_path / "log"
+    log_dir.mkdir()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            str(docs),
+            "--prompts",
+            "tests/data/p1.txt",
+            "--log-file",
+            str(log_dir),
+            "--no-inplace",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Cannot write to log file" in result.stderr
+
+
+def test_log_file_resolution(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+
+    cli = import_cli()
+
+    captured = {}
+
+    def fake_process_folder(
+        folder: Path,
+        prompt_paths: list[Path],
+        model: str,
+        max_tokens: int | None = None,
+        regex_json: Path | None = None,
+        dry_run: bool = False,
+        verbose: bool = False,
+        inplace: bool = False,
+        log_file: Path | None = None,
+    ) -> None:
+        captured["log_file"] = log_file
+
+    monkeypatch.setattr(cli, "process_folder", fake_process_folder)
+
+    (tmp_path / "a.md").write_text("A")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            str(tmp_path),
+            "--prompts",
+            "tests/data/p1.txt",
+            "--log-file",
+            "out.txt",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["log_file"] == Path.cwd() / Path("out.txt")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from .runner import run_cli
+
+
+def test_extraction_mode(tmp_path: Path):
+    # create sample markdown files
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    files = [docs / "a.md", docs / "b.md"]
+    for f in files:
+        f.write_text(f"{f.stem.upper()}")
+
+    # create prompts
+    p1 = tmp_path / "p1.txt"
+    p1.write_text("P1")
+    p2 = tmp_path / "p2.txt"
+    p2.write_text("P2")
+
+    log_path = tmp_path / "log.txt"
+
+    proc = run_cli(
+        [
+            str(docs),
+            "--prompts",
+            str(p1),
+            "--prompts",
+            str(p2),
+            "--log-file",
+            str(log_path),
+            "--no-inplace",
+        ],
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    # files should be unchanged
+    assert [f.read_text() for f in files] == ["A", "B"]
+
+    content = log_path.read_text()
+    blocks = [b for b in content.split("\n---\n") if b.strip()]
+    assert len(blocks) == 4
+
+    expected = [
+        ("=== a.md | prompt: p1.txt ===", "A[P1]"),
+        ("=== a.md | prompt: p2.txt ===", "A[P1][P2]"),
+        ("=== b.md | prompt: p1.txt ===", "B[P1]"),
+        ("=== b.md | prompt: p2.txt ===", "B[P1][P2]"),
+    ]
+
+    for header, text in expected:
+        matching = [b for b in blocks if header in b]
+        assert matching, f"missing block for {header}"
+        assert text in matching[0]
+
+    # run again in inplace mode and ensure log stays empty
+    proc = run_cli(
+        [
+            str(docs),
+            "--prompts",
+            str(p1),
+            "--prompts",
+            str(p2),
+            "--log-file",
+            str(log_path),
+            "--inplace",
+        ],
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert [f.read_text() for f in files] == ["A[P1][P2]", "B[P1][P2]"]
+    assert log_path.read_text() == content

--- a/tests/test_log_io.py
+++ b/tests/test_log_io.py
@@ -1,11 +1,12 @@
-import tempfile, textwrap
-from pathlib import Path
 from md_batch_gpt.log_io import append_log_record
+
 
 def test_append_log_record(tmp_path):
     log = tmp_path / "log.txt"
-    src = tmp_path / "a.md"; src.write_text("dummy")
-    prm = tmp_path / "p.txt"; prm.write_text("prompt")
+    src = tmp_path / "a.md"
+    src.write_text("dummy")
+    prm = tmp_path / "p.txt"
+    prm.write_text("prompt")
     append_log_record(log, src, prm, "OUTPUT")
     content = log.read_text(encoding="utf-8")
     assert "=== a.md | prompt: p.txt ===" in content

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -101,6 +101,32 @@ def test_process_folder_verbose(monkeypatch, tmp_path: Path, capsys):
     assert "a.md: pass 2/2" in out_lines[1]
 
 
+def test_process_folder_verbose_logging(monkeypatch, tmp_path: Path, capsys):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    orch = import_orchestrator()
+
+    monkeypatch.setattr(
+        orch,
+        "send_prompt",
+        lambda prompt, content, model, max_tokens=None: f"{content}[{prompt}]",
+    )
+
+    md = tmp_path / "a.md"
+    md.write_text("A")
+    p = tmp_path / "p.txt"
+    p.write_text("p")
+
+    log_file = tmp_path / "log.txt"
+
+    orch.process_folder(
+        tmp_path, [p], model="m", verbose=True, inplace=False, log_file=log_file
+    )
+
+    lines = capsys.readouterr().out.splitlines()
+    assert "a.md: pass 1/1" in lines[0]
+    assert f"log record 1: {md} {p.name}" in lines[1]
+
+
 def test_process_folder_max_tokens(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     orch = import_orchestrator()


### PR DESCRIPTION
## Summary
- resolve log path relative to current working directory
- echo log record details when verbose is enabled
- test CLI log path resolution
- test verbose logging in orchestrator
- document new logging behavior in README
- bump version to 0.1.1 and add changelog

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6877b41c1d2483268b9c9f63ebd59879